### PR TITLE
Feat: Add User image input for Card component

### DIFF
--- a/src/components/card/Card.jsx
+++ b/src/components/card/Card.jsx
@@ -17,12 +17,32 @@ const CardStyle = styled.div`
   margin: 0;
 `;
 
-const ImagePlaceholder = styled.div`
+const ImagePlaceholder = styled.img`
   width: 90%;
   height: ${({ width }) => width * 0.75}px;
   background-color: white;
   border-radius: 10px;
   margin-bottom: ${({ width }) => width * 0.05}px;
+  object-fit: cover;
+`;
+
+const SkeletonPlaceholder = styled.div`
+  width: 90%;
+  height: ${({ width }) => width * 0.75}px;
+  background: linear-gradient(-135deg, #e0e0e0 25%, #f5f5f5 50%, #e0e0e0 75%);
+  background-size: 200% 100%;
+  border-radius: 10px;
+  margin-bottom: ${({ width }) => width * 0.05}px;
+  animation: skeleton-loading 3s infinite linear;
+
+  @keyframes skeleton-loading {
+    0% {
+      background-position: 200% 0;
+    }
+    100% {
+      background-position: -200% 0;
+    }
+  }
 `;
 
 const Title = styled.h3`
@@ -57,12 +77,16 @@ const HireButton = styled.button`
   }
 `;
 
-const Card = ({ title, description, buttonText, width }) => {
+const Card = ({ title, description, buttonText, width, imageSrc }) => {
   const iconWidth = width * 0.15;
 
   return (
     <CardStyle width={width}>
-      <ImagePlaceholder width={width} />
+      {imageSrc ? (
+        <ImagePlaceholder src={imageSrc} width={width} />
+      ) : (
+        <SkeletonPlaceholder width={width} />
+      )}
       <Title width={width}>{title}</Title>
       <Description width={width}>{description}</Description>
       <IconRow width={width}>
@@ -80,6 +104,7 @@ Card.propTypes = {
   description: PropTypes.string.isRequired,
   buttonText: PropTypes.string.isRequired,
   width: PropTypes.number,
+  imageSrc: PropTypes.string,
 };
 
 Card.defaultProps = {
@@ -87,4 +112,5 @@ Card.defaultProps = {
   description: '저 밥 조금만 먹어요',
   buttonText: 'Hire Me',
   width: 200,
+  imageSrc: '',
 };

--- a/src/components/card/Card.stories.jsx
+++ b/src/components/card/Card.stories.jsx
@@ -12,6 +12,7 @@ export default {
     title: { control: 'text', description: '카드의 제목' },
     description: { control: 'text', description: '카드의 설명' },
     buttonText: { control: 'text', description: '버튼의 텍스트' },
+    imageSrc: { control: 'text', description: '이미지 경로' },
   },
 };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#2 

## 작업 내용
이번 PR에서 작업한 내용을 자세히 설명해주세요(이미지 첨부 가능)

- Card 컴포넌트에 사용자 입력으로 이미지 URL을 받아 해당 이미지를 표시할 수 있게 했습니다.
- 사용자 입력 전까지 스켈레톤 UI가 렌더링 되게 했습니다.

## 스크린샷 (선택)
![user_input](https://github.com/user-attachments/assets/f482b692-adff-4efc-a4cc-a6478180a355)


## storybook 문서 추가 (선택)


### 파라미터 설명

| Name       | Description | Type   | Default        | Control    |
|------------|-------------|--------|----------------|------------|
| imageSrc      | 이미지 경로 | string |       ''        |  text          |



## 리뷰 요구사항(선택)

실제 렌더링 되는 스켈레톤 UI는 gif 캡쳐본과 약간 다릅니다!  스토리북으로 확인 부탁드립니다~!